### PR TITLE
在webpack下混用import和module.exports会导致错误

### DIFF
--- a/libs/props/range.js
+++ b/libs/props/range.js
@@ -1,4 +1,4 @@
-import { createPropType } from '../utils';
+var createPropType = require('../utils').createPropType;
 
 module.exports = (min, max) => {
   return createPropType((props, propName, componentName) => {


### PR DESCRIPTION
在webpack下混用import和module.exports会导致错误Uncaught TypeError: Cannot assign to read only property 'exports' of object '#<Object>'
这个错误在webpack的issues里有提及 https://github.com/webpack/webpack/issues/4039

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you are merging your commits to `master` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
* [ ] Rebase your commits to make your pull request meaningful.
* [ ] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

-
