### PR TITLE
文件名为react会导致import React from 'react'不能被正确编译

### DIFF
--- a/libs/utils/index.js
+++ b/libs/utils/index.js
@@ -1,5 +1,5 @@
 import {require_condition} from './assert'
-import * as ReactUtils from './react'
+import * as ReactUtils from './firstChild'
 import * as Errors from './errors'
 
 export {require_condition, ReactUtils, Errors}


### PR DESCRIPTION
文件名为react会导致import React from 'react'不能被正确编译
在webpack下编译后得到
var React = require("react") 浏览器抛出错误“require is not defined”
不能正确地编译为
var React = __webpack_require__(0)

Please makes sure these boxes are checked before submitting your PR, thank you!

* [ ] Make sure you are merging your commits to `master` branch.
* [ ] Add some descriptions and refer relative issues for you PR.
* [ ] Rebase your commits to make your pull request meaningful.
* [ ] Make sure that your changes pass `npm test`, `npm run lint` and `npm run build`.

Changes in this pull request

-
